### PR TITLE
MockBuilder: add support for traits with methods with the same name

### DIFF
--- a/mock-builder/src/location.rs
+++ b/mock-builder/src/location.rs
@@ -2,9 +2,27 @@ use frame_support::StorageHasher;
 
 use super::util::TypeSignature;
 
+/// Indicate how to perform the localtion hash
+/// See `FunctionLocation::hash()`
+#[derive(Clone, Copy, Debug)]
+pub enum TraitInfo {
+	/// Create has with trait info, panics if it has not.
+	Yes,
+
+	/// Create hash with no trait info
+	No,
+
+	/// Create the hash with the trait info if it has trait info
+	/// or not if it has not.
+	Whatever,
+}
+
 /// Absolute string identification of function.
 #[derive(Clone, PartialEq, Eq, Debug)]
-pub struct FunctionLocation(String);
+pub struct FunctionLocation {
+	location: String,
+	trait_info: Option<String>,
+}
 
 impl FunctionLocation {
 	/// Creates a location for the function which created the given closure used
@@ -32,42 +50,104 @@ impl FunctionLocation {
 			})
 			.unwrap_or(location);
 
-		Self(location.into())
+		Self {
+			location: location.into(),
+			trait_info: Default::default(),
+		}
 	}
 
 	/// Normalize the location, allowing to identify the function
 	/// no matter if it belongs to a trait or not.
 	pub fn normalize(self) -> Self {
-		let (path, name) = self.0.rsplit_once("::").expect("always ::");
-		let path = path
-			.strip_prefix('<')
-			.map(|trait_path| trait_path.split_once(" as").expect("always ' as'").0)
-			.unwrap_or(path);
+		let (path, name) = self.location.rsplit_once("::").expect("always '::'");
+		let (path, trait_info) = match path.strip_prefix('<') {
+			Some(struct_as_trait_path) => {
+				let struct_path = struct_as_trait_path
+					.split_once(" as")
+					.expect("always ' as'")
+					.0;
 
-		Self(format!("{path}::{name}"))
+				let trait_name = struct_as_trait_path
+					.rsplit_once("::")
+					.expect("always '::'")
+					.1
+					.strip_suffix('>')
+					.unwrap();
+
+				(struct_path, Some(trait_name.to_owned()))
+			}
+			None => (path, None),
+		};
+
+		Self {
+			location: format!("{path}::{name}"),
+			trait_info,
+		}
 	}
 
 	/// Remove the prefix from the function name.
 	pub fn strip_name_prefix(self, prefix: &str) -> Self {
-		let (path, name) = self.0.rsplit_once("::").expect("always ::");
+		let (path, name) = self.location.rsplit_once("::").expect("always ::");
 		let name = name.strip_prefix(prefix).unwrap_or_else(|| {
 			panic!(
 				"Function '{name}' should have a '{prefix}' prefix. Location: {}",
-				self.0
+				self.location
 			)
 		});
 
-		Self(format!("{path}::{name}"))
+		Self {
+			location: format!("{path}::{name}"),
+			trait_info: self.trait_info,
+		}
+	}
+
+	/// Remove the trait name from the function name and add such information to
+	/// the location. The location is expected to have the following structure:
+	/// `<path>::<TraitInfo>_<name>`
+	pub fn assimilate_trait_prefix(self) -> Self {
+		let (path, name) = self.location.rsplit_once("::").expect("always ::");
+		let (trait_info, name) = match name.chars().next().unwrap().is_uppercase() {
+			true => {
+				let (trait_info, name) = name.split_once('_').expect("always '_' after trait name");
+				(Some(trait_info.to_owned()), name)
+			}
+			false => (None, name),
+		};
+
+		Self {
+			location: format!("{path}::{name}"),
+			trait_info,
+		}
 	}
 
 	/// Add a representation of the function input and output types
 	pub fn append_type_signature<I, O>(self) -> Self {
-		Self(format!("{}:{}", self.0, TypeSignature::new::<I, O>()))
+		Self {
+			location: format!("{}:{}", self.location, TypeSignature::new::<I, O>()),
+			trait_info: self.trait_info,
+		}
 	}
 
 	/// Generate a hash of the location
-	pub fn hash<Hasher: StorageHasher>(&self) -> Hasher::Output {
-		Hasher::hash(self.0.as_bytes())
+	pub fn hash<Hasher: StorageHasher>(&self, trait_info: TraitInfo) -> Hasher::Output {
+		let string = match trait_info {
+			TraitInfo::Yes => {
+				let trait_info = self
+					.trait_info
+					.as_ref()
+					.expect("Location must have trait info");
+				format!("{}{}", self.location, trait_info)
+			}
+			TraitInfo::No => self.location.clone(),
+			TraitInfo::Whatever => {
+				let trait_info = self.trait_info.clone().unwrap_or_default();
+				format!("{}{}", self.location, trait_info)
+			}
+		};
+
+		dbg!(trait_info, &string);
+
+		Hasher::hash(string.as_bytes())
 	}
 }
 
@@ -89,6 +169,11 @@ mod tests {
 			FunctionLocation::from(|| ())
 		}
 
+		#[allow(non_snake_case)]
+		fn mock_TraitExample_method() -> FunctionLocation {
+			FunctionLocation::from(|| ())
+		}
+
 		fn mock_generic_method<A: Into<i32>>(_: impl Into<u32>) -> FunctionLocation {
 			FunctionLocation::from(|| ())
 		}
@@ -107,52 +192,115 @@ mod tests {
 	#[test]
 	fn function_location() {
 		assert_eq!(
-			Example::mock_method().0,
-			format!("{PREFIX}::Example::mock_method")
+			Example::mock_method(),
+			FunctionLocation {
+				location: format!("{PREFIX}::Example::mock_method"),
+				trait_info: None,
+			}
 		);
 
 		assert_eq!(
-			Example::mock_generic_method::<i8>(0u8).0,
-			format!("{PREFIX}::Example::mock_generic_method")
+			Example::mock_TraitExample_method(),
+			FunctionLocation {
+				location: format!("{PREFIX}::Example::mock_TraitExample_method"),
+				trait_info: None,
+			}
 		);
 
 		assert_eq!(
-			Example::method().0,
-			format!("<{PREFIX}::Example as {PREFIX}::TraitExample>::method")
+			Example::mock_generic_method::<i8>(0u8),
+			FunctionLocation {
+				location: format!("{PREFIX}::Example::mock_generic_method"),
+				trait_info: None,
+			}
 		);
 
 		assert_eq!(
-			Example::generic_method::<i8>(0u8).0,
-			format!("<{PREFIX}::Example as {PREFIX}::TraitExample>::generic_method")
+			Example::method(),
+			FunctionLocation {
+				location: format!("<{PREFIX}::Example as {PREFIX}::TraitExample>::method"),
+				trait_info: None,
+			}
+		);
+
+		assert_eq!(
+			Example::generic_method::<i8>(0u8),
+			FunctionLocation {
+				location: format!("<{PREFIX}::Example as {PREFIX}::TraitExample>::generic_method"),
+				trait_info: None,
+			}
 		);
 	}
 
 	#[test]
-	fn normalized_function_location() {
+	fn normalized() {
 		assert_eq!(
-			Example::mock_method().normalize().0,
-			format!("{PREFIX}::Example::mock_method")
+			Example::mock_method().normalize(),
+			FunctionLocation {
+				location: format!("{PREFIX}::Example::mock_method"),
+				trait_info: None,
+			}
 		);
 
 		assert_eq!(
-			Example::method().normalize().0,
-			format!("{PREFIX}::Example::method")
+			Example::mock_TraitExample_method().normalize(),
+			FunctionLocation {
+				location: format!("{PREFIX}::Example::mock_TraitExample_method"),
+				trait_info: None,
+			}
+		);
+
+		assert_eq!(
+			Example::method().normalize(),
+			FunctionLocation {
+				location: format!("{PREFIX}::Example::method"),
+				trait_info: Some("TraitExample".into()),
+			}
 		);
 	}
 
 	#[test]
-	fn striped_function_location() {
+	fn striped_name_prefix() {
 		assert_eq!(
-			Example::mock_method().strip_name_prefix("mock_").0,
-			format!("{PREFIX}::Example::method")
+			Example::mock_method().strip_name_prefix("mock_"),
+			FunctionLocation {
+				location: format!("{PREFIX}::Example::method"),
+				trait_info: None,
+			}
+		);
+	}
+
+	#[test]
+	fn assimilated_trait_prefix() {
+		assert_eq!(
+			Example::mock_method()
+				.strip_name_prefix("mock_")
+				.assimilate_trait_prefix(),
+			FunctionLocation {
+				location: format!("{PREFIX}::Example::method"),
+				trait_info: None,
+			}
+		);
+
+		assert_eq!(
+			Example::mock_TraitExample_method()
+				.strip_name_prefix("mock_")
+				.assimilate_trait_prefix(),
+			FunctionLocation {
+				location: format!("{PREFIX}::Example::method"),
+				trait_info: Some("TraitExample".into()),
+			}
 		);
 	}
 
 	#[test]
 	fn appended_type_signature() {
 		assert_eq!(
-			Example::mock_method().append_type_signature::<i8, u8>().0,
-			format!("{PREFIX}::Example::mock_method:i8->u8")
+			Example::mock_method().append_type_signature::<i8, u8>(),
+			FunctionLocation {
+				location: format!("{PREFIX}::Example::mock_method:i8->u8"),
+				trait_info: None,
+			}
 		);
 	}
 }

--- a/mock-builder/src/location.rs
+++ b/mock-builder/src/location.rs
@@ -6,14 +6,14 @@ use super::util::TypeSignature;
 /// See `FunctionLocation::hash()`
 #[derive(Clone, Copy, Debug)]
 pub enum TraitInfo {
-	/// Create has with trait info, panics if it has not.
+	/// Create hash with trait info, panics if it has not.
 	Yes,
 
 	/// Create hash with no trait info
 	No,
 
 	/// Create the hash with the trait info if it has trait info
-	/// or not if it has not.
+	/// or not if it has none.
 	Whatever,
 }
 
@@ -144,8 +144,6 @@ impl FunctionLocation {
 				format!("{}{}", self.location, trait_info)
 			}
 		};
-
-		dbg!(trait_info, &string);
 
 		Hasher::hash(string.as_bytes())
 	}


### PR DESCRIPTION
# Description

Add support for testing pallets that implement traits whose methods have the same name.

When a pallet, implements two traits with the same methods, the trait name should now be in the name signature (only needed in case of name collision, otherwise the pallet can be constructed as always). Example:

```rust
struct Pallet;

impl Pallet {
    #[allow(non_snake_case)]
    pub fn mock_TraitA_get(f: impl Fn(u64) -> usize + 'static) {
        register_call!(f);
    }

    #[allow(non_snake_case)]
    pub fn mock_TraitB_get(f: impl Fn(i32) -> bool + 'static) {
        register_call!(f);
    }
}

impl TraitA for Pallet {
    fn get(a: u64) -> usize {
        execute_call!(a)
    }
    
    fn get(a: i32) -> bool {
        execute_call!(a)
    }
}
```

**This change is retrocompatible**

Fixes https://github.com/centrifuge/centrifuge-chain/issues/1564


