### PR TITLE
Remove hashes from storages

### DIFF
--- a/mock-builder/CHANGELOG.md
+++ b/mock-builder/CHANGELOG.md
@@ -3,12 +3,5 @@
 ## Release 0.2.0
 - Remove hashes in storages for pallet mocks
 
-## Release 0.1.2
-- Support for `polkadot-v1.0.0`
-
-## Release 0.1.1
-- Support for `polkadot-v0.9.43`
-
 ## Release 0.1.0
 - Base functionality
-- Support for `polkadot-v0.9.38`

--- a/mock-builder/CHANGELOG.md
+++ b/mock-builder/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## Release 0.2.0
+- Remove hashes in storages for pallet mocks
+
+## Release 0.1.0
+- Base functionality

--- a/mock-builder/CHANGELOG.md
+++ b/mock-builder/CHANGELOG.md
@@ -3,5 +3,12 @@
 ## Release 0.2.0
 - Remove hashes in storages for pallet mocks
 
+## Release 0.1.2
+- Support for `polkadot-v1.0.0`
+
+## Release 0.1.1
+- Support for `polkadot-v0.9.43`
+
 ## Release 0.1.0
 - Base functionality
+- Support for `polkadot-v0.9.38`

--- a/mock-builder/Cargo.toml
+++ b/mock-builder/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "LGPL-3.0"
 name = "mock-builder"
 repository = "https://github.com/centrifuge/centrifuge-chain"
-version = "0.1.2"
+version = "0.2.0"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/mock-builder/src/location.rs
+++ b/mock-builder/src/location.rs
@@ -1,5 +1,3 @@
-use frame_support::StorageHasher;
-
 use super::util::TypeSignature;
 
 /// Indicate how to perform the localtion hash
@@ -129,23 +127,14 @@ impl FunctionLocation {
 	}
 
 	/// Generate a hash of the location
-	pub fn hash<Hasher: StorageHasher>(&self, trait_info: TraitInfo) -> Hasher::Output {
-		let string = match trait_info {
-			TraitInfo::Yes => {
-				let trait_info = self
-					.trait_info
-					.as_ref()
-					.expect("Location must have trait info");
-				format!("{}{}", self.location, trait_info)
-			}
-			TraitInfo::No => self.location.clone(),
-			TraitInfo::Whatever => {
-				let trait_info = self.trait_info.clone().unwrap_or_default();
-				format!("{}{}", self.location, trait_info)
-			}
+	pub fn get(&self, trait_info: TraitInfo) -> String {
+		let trait_info = match trait_info {
+			TraitInfo::Yes => self.trait_info.clone().unwrap(),
+			TraitInfo::No => String::default(),
+			TraitInfo::Whatever => self.trait_info.clone().unwrap_or_default(),
 		};
 
-		Hasher::hash(string.as_bytes())
+		format!("{},trait={}", self.location, trait_info)
 	}
 }
 

--- a/mock-builder/tests/pallet.rs
+++ b/mock-builder/tests/pallet.rs
@@ -17,7 +17,7 @@ pub trait Storage {
 	fn get() -> i32;
 }
 
-#[frame_support::pallet]
+#[frame_support::pallet(dev_mode)]
 pub mod pallet_mock_test {
 	use frame_support::pallet_prelude::*;
 	use mock_builder::{execute_call, register_call};
@@ -29,12 +29,7 @@ pub mod pallet_mock_test {
 	pub struct Pallet<T>(_);
 
 	#[pallet::storage]
-	pub(super) type CallIds<T: Config> = StorageMap<
-		_,
-		Blake2_128Concat,
-		<Blake2_128 as frame_support::StorageHasher>::Output,
-		mock_builder::CallId,
-	>;
+	pub(super) type CallIds<T: Config> = StorageMap<_, _, String, mock_builder::CallId>;
 
 	impl<T: Config> Pallet<T> {
 		pub fn mock_foo(f: impl Fn(String, Option<u64>) + 'static) {


### PR DESCRIPTION
Using `dev_mode` allows to use of something no hashable for Storages, reducing the complexity of setting up a mock-pallet and debugging it in case of some error.

- Added `CHANGELOG.md` file for `mock-builder` for tracking API changes now that it will be public.