### PR TITLE
MockBuilder: Remove polkadot dependency

### DIFF
--- a/mock-builder/Cargo.toml
+++ b/mock-builder/Cargo.toml
@@ -10,11 +10,9 @@ version = "0.2.0"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
-[dependencies]
-frame-support = { workspace = true }
-
 [dev-dependencies]
 codec = { package = "parity-scale-codec", workspace = true, features = ["default"] }
+frame-support = { workspace = true features = ["default"] }
 frame-system = { workspace = true, features = ["default"] }
 scale-info = { workspace = true, features = ["default"] }
 sp-core = { workspace = true, features = ["default"] }

--- a/mock-builder/Cargo.toml
+++ b/mock-builder/Cargo.toml
@@ -12,7 +12,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dev-dependencies]
 codec = { package = "parity-scale-codec", workspace = true, features = ["default"] }
-frame-support = { workspace = true features = ["default"] }
+frame-support = { workspace = true, features = ["default"] }
 frame-system = { workspace = true, features = ["default"] }
 scale-info = { workspace = true, features = ["default"] }
 sp-core = { workspace = true, features = ["default"] }

--- a/mock-builder/src/lib.rs
+++ b/mock-builder/src/lib.rs
@@ -271,11 +271,11 @@ pub const MOCK_FN_PREFIX: &str = "mock_";
 /// Register a mock function into the mock function storage.
 /// This function should be called with a locator used as a function
 /// identification.
-pub fn register<Locator, F, I, O, Setter>(locator: Locator, f: F, setter: Setter)
+pub fn register<Locator, F, I, O, Insert>(locator: Locator, f: F, insert: Insert)
 where
 	Locator: Fn(),
 	F: Fn(I) -> O + 'static,
-	Setter: Fn(String, CallId),
+	Insert: Fn(String, CallId),
 {
 	let location = FunctionLocation::from(locator)
 		.normalize()
@@ -283,23 +283,23 @@ where
 		.assimilate_trait_prefix()
 		.append_type_signature::<I, O>();
 
-	setter(location.get(TraitInfo::Whatever), storage::register_call(f))
+	insert(location.get(TraitInfo::Whatever), storage::register_call(f))
 }
 
 /// Execute a function from the function storage.
 /// This function should be called with a locator used as a function
 /// identification.
-pub fn execute<Locator, I, O, Getter>(locator: Locator, input: I, getter: Getter) -> O
+pub fn execute<Locator, I, O, Get>(locator: Locator, input: I, get: Get) -> O
 where
 	Locator: Fn(),
-	Getter: Fn(String) -> Option<CallId>,
+	Get: Fn(String) -> Option<CallId>,
 {
 	let location = FunctionLocation::from(locator)
 		.normalize()
 		.append_type_signature::<I, O>();
 
-	let call_id = getter(location.get(TraitInfo::Yes))
-		.or_else(|| getter(location.get(TraitInfo::No)))
+	let call_id = get(location.get(TraitInfo::Yes))
+		.or_else(|| get(location.get(TraitInfo::No)))
 		.unwrap_or_else(|| panic!("Mock was not found. Location: {location:?}"));
 
 	storage::execute_call(call_id, input).unwrap_or_else(|err| {

--- a/mock-builder/src/lib.rs
+++ b/mock-builder/src/lib.rs
@@ -57,7 +57,7 @@
 //! associated type in our `Config`, which implements traits `TraitA` and
 //! `TraitB`. Those traits are defined as follows:
 //!
-//! ```no_run
+//! ```
 //! trait TraitA {
 //!     type AssocA;
 //!
@@ -143,7 +143,7 @@
 //! The only condition to use these macros is to have the following storage in
 //! the pallet (it's safe to just copy and paste this snippet in your pallet):
 //!
-//! ```no_run
+//! ```
 //! # #[frame_support::pallet(dev_mode)]
 //! # mod pallet {
 //! # use frame_support::pallet_prelude::*;
@@ -153,7 +153,7 @@
 //! # pub struct Pallet<T>(_);
 //!
 //! #[pallet::storage]
-//! pub(super) type CallIds<T: Config> = StorageMap<_, _, String, mock_builder::CallId>;
+//! type CallIds<T: Config> = StorageMap<_, _, String, mock_builder::CallId>;
 //!
 //! # }
 //! ```
@@ -161,7 +161,7 @@
 //! Following the above example, generating a *mock pallet* for both `TraitA`
 //! and `TraitB` is done as follows:
 //!
-//! ```no_run
+//! ```
 //! #[frame_support::pallet(dev_mode)]
 //! pub mod pallet {
 //!     # trait TraitA {
@@ -189,7 +189,7 @@
 //!     pub struct Pallet<T>(_);
 //!
 //!     #[pallet::storage]
-//!     pub(super) type CallIds<T: Config> = StorageMap<_, _, String, mock_builder::CallId>;
+//!     type CallIds<T: Config> = StorageMap<_, _, String, mock_builder::CallId>;
 //!
 //!     impl<T: Config> Pallet<T> {
 //!         fn mock_foo(f: impl Fn() -> T::AssocA + 'static) {

--- a/mock-builder/tests/pallet.rs
+++ b/mock-builder/tests/pallet.rs
@@ -29,7 +29,7 @@ pub mod pallet_mock_test {
 	pub struct Pallet<T>(_);
 
 	#[pallet::storage]
-	pub(super) type CallIds<T: Config> = StorageMap<_, _, String, mock_builder::CallId>;
+	type CallIds<T: Config> = StorageMap<_, _, String, mock_builder::CallId>;
 
 	impl<T: Config> Pallet<T> {
 		pub fn mock_foo(f: impl Fn(String, Option<u64>) + 'static) {


### PR DESCRIPTION
This PR removes the last polkadot dependency (`StorageMap`) from non-test & non-macro code.

This has become a requirement since if we want to push any example with `mock-builder` in `polkadot-sdk` repo, it creates a circular dependency: `polkadot-sdk -> mock-builder -> polkadot-sdk`, mismatching the types and not allowing to compile there.

It has been lucky that we were able to remove all polkadot dependencies, if not, it would be impossible to create a compiling example there 😆 