### PR TITLE
MockBuilder: extend trait generic support when the generics are themself generic

### DIFF
--- a/mock-builder/src/location.rs
+++ b/mock-builder/src/location.rs
@@ -60,23 +60,17 @@ impl FunctionLocation {
 		let (path, name) = self.location.rsplit_once("::").expect("always '::'");
 		let (path, trait_info) = match path.strip_prefix('<') {
 			Some(struct_as_trait_path) => {
-				let struct_path = struct_as_trait_path
+				let (struct_path, trait_path) = struct_as_trait_path
 					.split_once(" as")
-					.expect("always ' as'")
-					.0;
+					.expect("always ' as'");
 
-				let trait_name = struct_as_trait_path
-					.rsplit_once("::")
-					.expect("always '::'")
-					.1
-					.strip_suffix('>')
-					.unwrap();
-
-				// Remove generic from trait name
-				let trait_name = trait_name
+				let trait_name = trait_path
 					.split_once('<')
-					.map(|(fst, _)| fst)
-					.unwrap_or(trait_name);
+					.map(|(name, _generics)| name)
+					.unwrap_or(trait_path.strip_suffix('>').unwrap())
+					.rsplit_once("::")
+					.expect("Always '::'")
+					.1;
 
 				(struct_path, Some(trait_name.to_owned()))
 			}
@@ -159,9 +153,13 @@ mod tests {
 		fn generic() -> FunctionLocation;
 	}
 
-	struct Example;
+	trait Config {
+		type Assoc;
+	}
 
-	impl Example {
+	struct Example<T>(core::marker::PhantomData<T>);
+
+	impl<T> Example<T> {
 		fn mock_method() -> FunctionLocation {
 			FunctionLocation::from(|| ())
 		}
@@ -181,7 +179,7 @@ mod tests {
 		}
 	}
 
-	impl TraitExample for Example {
+	impl<T> TraitExample for Example<T> {
 		fn method() -> FunctionLocation {
 			FunctionLocation::from(|| ())
 		}
@@ -191,59 +189,68 @@ mod tests {
 		}
 	}
 
-	impl TraitExampleGen<u32, bool> for Example {
+	impl<T: Config> TraitExampleGen<T::Assoc, bool> for Example<T> {
 		fn generic() -> FunctionLocation {
 			FunctionLocation::from(|| ())
 		}
 	}
 
+	struct TestConfig;
+	impl Config for TestConfig {
+		type Assoc = u32;
+	}
+
 	#[test]
 	fn function_location() {
 		assert_eq!(
-			Example::mock_method(),
+			Example::<TestConfig>::mock_method(),
 			FunctionLocation {
-				location: format!("{PREFIX}::Example::mock_method"),
+				location: format!("{PREFIX}::Example<{PREFIX}::TestConfig>::mock_method"),
 				trait_info: None,
 			}
 		);
 
 		assert_eq!(
-			Example::mock_TraitExample_method(),
-			FunctionLocation {
-				location: format!("{PREFIX}::Example::mock_TraitExample_method"),
-				trait_info: None,
-			}
-		);
-
-		assert_eq!(
-			Example::mock_generic_method::<i8>(0u8),
-			FunctionLocation {
-				location: format!("{PREFIX}::Example::mock_generic_method"),
-				trait_info: None,
-			}
-		);
-
-		assert_eq!(
-			Example::method(),
-			FunctionLocation {
-				location: format!("<{PREFIX}::Example as {PREFIX}::TraitExample>::method"),
-				trait_info: None,
-			}
-		);
-
-		assert_eq!(
-			Example::generic_method::<i8>(0u8),
-			FunctionLocation {
-				location: format!("<{PREFIX}::Example as {PREFIX}::TraitExample>::generic_method"),
-				trait_info: None,
-			}
-		);
-
-		assert_eq!(
-			Example::generic(),
+			Example::<TestConfig>::mock_TraitExample_method(),
 			FunctionLocation {
 				location: format!(
-					"<{PREFIX}::Example as {PREFIX}::TraitExampleGen<u32, bool>>::generic"
+					"{PREFIX}::Example<{PREFIX}::TestConfig>::mock_TraitExample_method"
+				),
+				trait_info: None,
+			}
+		);
+
+		assert_eq!(
+			Example::<TestConfig>::mock_generic_method::<i8>(0u8),
+			FunctionLocation {
+				location: format!("{PREFIX}::Example<{PREFIX}::TestConfig>::mock_generic_method"),
+				trait_info: None,
+			}
+		);
+
+		assert_eq!(
+			Example::<TestConfig>::method(),
+			FunctionLocation {
+				location: format!(
+					"<{PREFIX}::Example<{PREFIX}::TestConfig> as {PREFIX}::TraitExample>::method"
+				),
+				trait_info: None,
+			}
+		);
+
+		assert_eq!(
+			Example::<TestConfig>::generic_method::<i8>(0u8),
+			FunctionLocation {
+				location: format!("<{PREFIX}::Example<{PREFIX}::TestConfig> as {PREFIX}::TraitExample>::generic_method"),
+				trait_info: None,
+			}
+		);
+
+		assert_eq!(
+			Example::<TestConfig>::generic(),
+			FunctionLocation {
+				location: format!(
+					"<{PREFIX}::Example<{PREFIX}::TestConfig> as {PREFIX}::TraitExampleGen<<{PREFIX}::TestConfig as {PREFIX}::Config>::Assoc, bool>>::generic"
 				),
 				trait_info: None,
 			}
@@ -253,33 +260,35 @@ mod tests {
 	#[test]
 	fn normalized() {
 		assert_eq!(
-			Example::mock_method().normalize(),
+			Example::<TestConfig>::mock_method().normalize(),
 			FunctionLocation {
-				location: format!("{PREFIX}::Example::mock_method"),
+				location: format!("{PREFIX}::Example<{PREFIX}::TestConfig>::mock_method"),
 				trait_info: None,
 			}
 		);
 
 		assert_eq!(
-			Example::mock_TraitExample_method().normalize(),
+			Example::<TestConfig>::mock_TraitExample_method().normalize(),
 			FunctionLocation {
-				location: format!("{PREFIX}::Example::mock_TraitExample_method"),
+				location: format!(
+					"{PREFIX}::Example<{PREFIX}::TestConfig>::mock_TraitExample_method"
+				),
 				trait_info: None,
 			}
 		);
 
 		assert_eq!(
-			Example::method().normalize(),
+			Example::<TestConfig>::method().normalize(),
 			FunctionLocation {
-				location: format!("{PREFIX}::Example::method"),
+				location: format!("{PREFIX}::Example<{PREFIX}::TestConfig>::method"),
 				trait_info: Some("TraitExample".into()),
 			}
 		);
 
 		assert_eq!(
-			Example::generic().normalize(),
+			Example::<TestConfig>::generic().normalize(),
 			FunctionLocation {
-				location: format!("{PREFIX}::Example::generic"),
+				location: format!("{PREFIX}::Example<{PREFIX}::TestConfig>::generic"),
 				trait_info: Some("TraitExampleGen".into()),
 			}
 		);
@@ -288,10 +297,10 @@ mod tests {
 	#[test]
 	fn striped_name_prefix() {
 		assert_eq!(
-			Example::mock_method().strip_name_prefix("mock_"),
+			Example::<TestConfig>::mock_method().strip_name_prefix("mock_"),
 			FunctionLocation {
-				location: format!("{PREFIX}::Example::method"),
-				trait_info: None
+				location: format!("{PREFIX}::Example<{PREFIX}::TestConfig>::method"),
+				trait_info: None,
 			}
 		);
 	}
@@ -299,31 +308,31 @@ mod tests {
 	#[test]
 	fn assimilated_trait_prefix() {
 		assert_eq!(
-			Example::mock_method()
+			Example::<TestConfig>::mock_method()
 				.strip_name_prefix("mock_")
 				.assimilate_trait_prefix(),
 			FunctionLocation {
-				location: format!("{PREFIX}::Example::method"),
-				trait_info: None
+				location: format!("{PREFIX}::Example<{PREFIX}::TestConfig>::method"),
+				trait_info: None,
 			}
 		);
 
 		assert_eq!(
-			Example::mock_TraitExample_method()
+			Example::<TestConfig>::mock_TraitExample_method()
 				.strip_name_prefix("mock_")
 				.assimilate_trait_prefix(),
 			FunctionLocation {
-				location: format!("{PREFIX}::Example::method"),
+				location: format!("{PREFIX}::Example<{PREFIX}::TestConfig>::method"),
 				trait_info: Some("TraitExample".into()),
 			}
 		);
 
 		assert_eq!(
-			Example::mock_TraitExampleGen_generic()
+			Example::<TestConfig>::mock_TraitExampleGen_generic()
 				.strip_name_prefix("mock_")
 				.assimilate_trait_prefix(),
 			FunctionLocation {
-				location: format!("{PREFIX}::Example::generic"),
+				location: format!("{PREFIX}::Example<{PREFIX}::TestConfig>::generic"),
 				trait_info: Some("TraitExampleGen".into()),
 			}
 		);
@@ -332,9 +341,9 @@ mod tests {
 	#[test]
 	fn appended_type_signature() {
 		assert_eq!(
-			Example::mock_method().append_type_signature::<i8, u8>(),
+			Example::<TestConfig>::mock_method().append_type_signature::<i8, u8>(),
 			FunctionLocation {
-				location: format!("{PREFIX}::Example::mock_method:i8->u8"),
+				location: format!("{PREFIX}::Example<{PREFIX}::TestConfig>::mock_method:i8->u8"),
 				trait_info: None,
 			}
 		);

--- a/mock-builder/src/location.rs
+++ b/mock-builder/src/location.rs
@@ -156,7 +156,7 @@ mod tests {
 	}
 
 	trait TraitExampleGen<G1, G2> {
-		fn foo() -> FunctionLocation;
+		fn generic() -> FunctionLocation;
 	}
 
 	struct Example;
@@ -168,6 +168,11 @@ mod tests {
 
 		#[allow(non_snake_case)]
 		fn mock_TraitExample_method() -> FunctionLocation {
+			FunctionLocation::from(|| ())
+		}
+
+		#[allow(non_snake_case)]
+		fn mock_TraitExampleGen_generic() -> FunctionLocation {
 			FunctionLocation::from(|| ())
 		}
 
@@ -187,7 +192,7 @@ mod tests {
 	}
 
 	impl TraitExampleGen<u32, bool> for Example {
-		fn foo() -> FunctionLocation {
+		fn generic() -> FunctionLocation {
 			FunctionLocation::from(|| ())
 		}
 	}
@@ -235,10 +240,10 @@ mod tests {
 		);
 
 		assert_eq!(
-			Example::foo(),
+			Example::generic(),
 			FunctionLocation {
 				location: format!(
-					"<{PREFIX}::Example as {PREFIX}::TraitExampleGen<u32, bool>>::foo"
+					"<{PREFIX}::Example as {PREFIX}::TraitExampleGen<u32, bool>>::generic"
 				),
 				trait_info: None,
 			}
@@ -272,9 +277,9 @@ mod tests {
 		);
 
 		assert_eq!(
-			Example::foo().normalize(),
+			Example::generic().normalize(),
 			FunctionLocation {
-				location: format!("{PREFIX}::Example::foo"),
+				location: format!("{PREFIX}::Example::generic"),
 				trait_info: Some("TraitExampleGen".into()),
 			}
 		);
@@ -310,6 +315,16 @@ mod tests {
 			FunctionLocation {
 				location: format!("{PREFIX}::Example::method"),
 				trait_info: Some("TraitExample".into()),
+			}
+		);
+
+		assert_eq!(
+			Example::mock_TraitExampleGen_generic()
+				.strip_name_prefix("mock_")
+				.assimilate_trait_prefix(),
+			FunctionLocation {
+				location: format!("{PREFIX}::Example::generic"),
+				trait_info: Some("TraitExampleGen".into()),
 			}
 		);
 	}

--- a/mock-builder/tests/pallet.rs
+++ b/mock-builder/tests/pallet.rs
@@ -12,6 +12,10 @@ pub trait TraitB {
 	fn same_name(p1: i32) -> bool;
 }
 
+pub trait TraitGen<A, B> {
+	fn generic() -> u32;
+}
+
 pub trait Storage {
 	fn set(value: i32);
 	fn get() -> i32;
@@ -73,6 +77,11 @@ pub mod pallet_mock_test {
 		pub fn mock_TraitB_same_name(f: impl Fn(i32) -> bool + 'static) {
 			register_call!(f);
 		}
+
+		#[allow(non_snake_case)]
+		pub fn mock_TraitGen_generic(f: impl Fn() -> u32 + 'static) {
+			register_call!(move |()| f());
+		}
 	}
 
 	impl<T: Config> super::TraitA for Pallet<T> {
@@ -108,6 +117,12 @@ pub mod pallet_mock_test {
 
 		fn same_name(a: i32) -> bool {
 			execute_call!(a)
+		}
+	}
+
+	impl<T: Config> super::TraitGen<u32, bool> for Pallet<T> {
+		fn generic() -> u32 {
+			execute_call!(())
 		}
 	}
 
@@ -198,7 +213,7 @@ mod mock {
 mod test {
 	use frame_support::assert_ok;
 
-	use super::{mock::*, Storage, TraitA, TraitB};
+	use super::{mock::*, Storage, TraitA, TraitB, TraitGen};
 
 	#[test]
 	fn basic() {
@@ -330,6 +345,15 @@ mod test {
 
 			assert_eq!(<MockTest as TraitA>::same_name(true, 42), 23);
 			assert_eq!(<MockTest as TraitB>::same_name(23), true);
+		});
+	}
+
+	#[test]
+	fn method_from_generic_trait_long_path() {
+		new_test_ext().execute_with(|| {
+			MockTest::mock_TraitGen_generic(|| 23);
+
+			assert_eq!(MockTest::generic(), 23);
 		});
 	}
 }

--- a/mock-builder/tests/pallet.rs
+++ b/mock-builder/tests/pallet.rs
@@ -12,7 +12,7 @@ pub trait TraitB {
 	fn same_name(p1: i32) -> bool;
 }
 
-pub trait TraitGen<A, B> {
+pub trait TraitGen<A> {
 	fn generic() -> u32;
 }
 
@@ -120,7 +120,7 @@ pub mod pallet_mock_test {
 		}
 	}
 
-	impl<T: Config> super::TraitGen<u32, bool> for Pallet<T> {
+	impl<T: Config> super::TraitGen<T::AccountId> for Pallet<T> {
 		fn generic() -> u32 {
 			execute_call!(())
 		}


### PR DESCRIPTION
Extends https://github.com/foss3/runtime-pallet-library/issues/14

For the cases where the generic parameter given to a trait is still generic.

Before: ie. `MyTrait<u32>` 
Now: i.e. `MyTrait<T::AccountId>`