### PR TITLE
Add `pallet-remarks` to Polkadot v1.0.0 branch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
   "mock-builder",
+  "pallets/remarks",
 ]
 resolver = "2"
 
@@ -13,12 +14,20 @@ description = "Runtime pallets and utilities for Substrate based chains"
 license = "LGPL-3.0"
 
 [workspace.dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", features = ["derive"] }
-scale-info = { version = "2.3.0", features = ["derive"] }
+parity-scale-codec = { version = "3.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.3.0", default-features = false, features = ["derive"] }
 
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0", default-features = false }
 frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0", default-features = false }
 frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0", default-features = false }
 
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0", default-features = false }
 sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0", default-features = false }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0", default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0", default-features = false }
+
+pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0", default-features = false }
+pallet-utility = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0", default-features = false }
+pallet-proxy = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0", default-features = false }
+
+mock-builder = { path = "mock-builder", default-features = false }

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ General purpose utilities and pallets for [_Substrate_](https://substrate.io/).
 
 ### Pallets
 
-None so far.
+- [`pallet-remarks`](pallets/remarks): Add remarks to calls
 
 ## Projects using RPL (Runtime Pallet Library)
 

--- a/mock-builder/Cargo.toml
+++ b/mock-builder/Cargo.toml
@@ -4,7 +4,7 @@ description = "Build mock pallets from traits"
 edition = "2021"
 license = "LGPL-3.0"
 name = "mock-builder"
-repository = "https://github.com/centrifuge/centrifuge-chain"
+repository = "https://github.com/foss3/runtime-pallet-library"
 version = "0.1.2"
 
 [package.metadata.docs.rs]
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 frame-support = { workspace = true }
 
 [dev-dependencies]
-codec = { package = "parity-scale-codec", workspace = true, features = ["default"] }
+parity-scale-codec = { workspace = true }
 frame-system = { workspace = true, features = ["default"] }
 scale-info = { workspace = true, features = ["default"] }
 sp-core = { workspace = true, features = ["default"] }

--- a/pallets/remarks/Cargo.toml
+++ b/pallets/remarks/Cargo.toml
@@ -1,0 +1,52 @@
+[package]
+name = "pallet-remarks"
+authors = ["Centrifuge <admin@centrifuge.io>"]
+description = "Remarks pallet for runtime"
+edition = "2021"
+license = "LGPL-3.0"
+repository = "https://github.com/foss3/runtime-pallet-library"
+version = "0.0.1"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+parity-scale-codec = { workspace = true }
+scale-info = { workspace = true }
+
+frame-benchmarking = { workspace = true }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+sp-runtime = { workspace = true }
+sp-std = { workspace = true }
+
+[dev-dependencies]
+mock-builder = { workspace = true, default-features = true }
+pallet-balances = { workspace = true, default-features = true }
+pallet-utility = { workspace = true, default-features = true }
+pallet-proxy = { workspace = true, default-features = true }
+sp-core = { workspace = true, default-features = true }
+sp-io = { workspace = true, default-features = true }
+
+[features]
+default = ["std"]
+std = [
+  "parity-scale-codec/std",
+  "scale-info/std",
+  "frame-benchmarking/std",
+  "frame-support/std",
+  "frame-system/std",
+  "sp-runtime/std",
+  "sp-std/std",
+]
+runtime-benchmarks = [
+  "frame-benchmarking/runtime-benchmarks",
+  "frame-support/runtime-benchmarks",
+  "frame-system/runtime-benchmarks",
+  "sp-runtime/runtime-benchmarks",
+]
+try-runtime = [
+  "frame-support/try-runtime",
+  "frame-system/try-runtime",
+  "sp-runtime/try-runtime",
+]

--- a/pallets/remarks/src/benchmarking.rs
+++ b/pallets/remarks/src/benchmarking.rs
@@ -1,0 +1,59 @@
+// Copyright 2023 Centrifuge Foundation (centrifuge.io).
+//
+// This file is part of the Centrifuge chain project.
+// Centrifuge is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version (see http://www.gnu.org/licenses).
+// Centrifuge is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+use frame_benchmarking::{account, impl_benchmark_test_suite, v2::*};
+use frame_support::BoundedVec;
+use frame_system::RawOrigin;
+use sp_std::{boxed::Box, cmp::min, vec, vec::Vec};
+
+use super::*;
+
+fn assert_last_event<T: Config>(generic_event: <T as Config>::RuntimeEvent) {
+	frame_system::Pallet::<T>::assert_last_event(generic_event.into());
+}
+
+#[benchmarks()]
+mod benchmarks {
+	use super::*;
+
+	#[benchmark]
+	fn remark(
+		n: Linear<1, { min(10, T::MaxRemarksPerCall::get()) }>,
+	) -> Result<(), BenchmarkError> {
+		let mut remarks = Vec::new();
+
+		for _ in 0..n {
+			remarks.push(T::Remark::default())
+		}
+
+		let remarks = BoundedVec::<T::Remark, T::MaxRemarksPerCall>::try_from(remarks)
+			.expect("can build remarks");
+
+		let caller: T::AccountId = account("acc_0", 0, 0);
+		let call: <T as Config>::RuntimeCall = frame_system::Call::remark { remark: vec![] }.into();
+
+		#[cfg(test)]
+		crate::mock::configure_mocks();
+
+		#[extrinsic_call]
+		remark(
+			RawOrigin::Signed(caller),
+			remarks.clone(),
+			Box::new(call.clone()),
+		);
+
+		assert_last_event::<T>(Event::Remark { remarks, call }.into());
+
+		Ok(())
+	}
+
+	impl_benchmark_test_suite!(Pallet, crate::mock::new_test_ext(), crate::mock::Runtime);
+}

--- a/pallets/remarks/src/lib.rs
+++ b/pallets/remarks/src/lib.rs
@@ -1,0 +1,162 @@
+// Copyright 2023 Centrifuge Foundation (centrifuge.io).
+//
+// This file is part of the Centrifuge chain project.
+// Centrifuge is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version (see http://www.gnu.org/licenses).
+// Centrifuge is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use frame_support::{
+	dispatch::GetDispatchInfo,
+	pallet_prelude::*,
+	traits::{IsSubType, OriginTrait},
+	BoundedVec,
+};
+use frame_system::pallet_prelude::*;
+pub use pallet::*;
+use sp_runtime::traits::Dispatchable;
+use sp_std::boxed::Box;
+pub use weights::WeightInfo;
+
+#[cfg(feature = "runtime-benchmarks")]
+mod benchmarking;
+
+#[cfg(test)]
+mod mock;
+#[cfg(test)]
+mod tests;
+
+mod weights;
+
+#[frame_support::pallet]
+pub mod pallet {
+	use super::*;
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {
+		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+
+		/// The handler used to check remarks before and after call dispatch.
+		type RemarkDispatchHandler: RemarkDispatchHandler<RemarkArgs<Self>>;
+
+		/// The overarching call type.
+		type RuntimeCall: Parameter
+			+ Dispatchable<RuntimeOrigin = Self::RuntimeOrigin>
+			+ GetDispatchInfo
+			+ From<frame_system::Call<Self>>
+			+ IsSubType<Call<Self>>
+			+ IsType<<Self as frame_system::Config>::RuntimeCall>;
+
+		/// Weight information.
+		type WeightInfo: WeightInfo;
+
+		/// The type attached to the remark event.
+		type Remark: Parameter + Member + Default;
+
+		/// Type that restrains the maximum remarks that can be attached to a
+		/// call.
+		type MaxRemarksPerCall: Get<u32>;
+	}
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	#[pallet::event]
+	#[pallet::generate_deposit(pub (super) fn deposit_event)]
+	pub enum Event<T: Config> {
+		/// A remark was made.
+		Remark {
+			remarks: BoundedVec<T::Remark, T::MaxRemarksPerCall>,
+			call: <T as Config>::RuntimeCall,
+		},
+	}
+
+	#[pallet::error]
+	pub enum Error<T> {
+		/// No remarks were provided.
+		NoRemarks,
+	}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		/// Add remarks to a call.
+		///
+		/// The weight calculation is similar to the one in the Proxy.proxy.
+		#[pallet::call_index(0)]
+		#[pallet::weight({
+			let dispatch_info = call.get_dispatch_info();
+			(T::WeightInfo::remark(T::MaxRemarksPerCall::get())
+				.saturating_add(dispatch_info.weight),
+			dispatch_info.class)
+		})]
+		pub fn remark(
+			origin: OriginFor<T>,
+			remarks: BoundedVec<T::Remark, T::MaxRemarksPerCall>,
+			call: Box<<T as Config>::RuntimeCall>,
+		) -> DispatchResult {
+			ensure!(!remarks.is_empty(), Error::<T>::NoRemarks);
+
+			T::RemarkDispatchHandler::pre_dispatch_check((
+				origin.clone(),
+				remarks.clone(),
+				call.clone(),
+			))?;
+
+			let mut filtered_origin = origin.clone();
+
+			// Nested remark calls are not allowed.
+			filtered_origin.add_filter(move |c: &<T as frame_system::Config>::RuntimeCall| {
+				let c = <T as Config>::RuntimeCall::from_ref(c);
+				!matches!(c.is_sub_type(), Some(Call::remark { .. }))
+			});
+
+			call.clone()
+				.dispatch(filtered_origin)
+				.map(|_| ())
+				.map_err(|e| e.error)?;
+
+			T::RemarkDispatchHandler::post_dispatch_check((origin, remarks.clone(), call.clone()))?;
+
+			Self::deposit_event(Event::Remark {
+				remarks,
+				call: *call,
+			});
+
+			Ok(())
+		}
+	}
+}
+
+/// The type used in the RemarkDispatchHandler trait of the pallet's Config.
+pub type RemarkArgs<T> = (
+	OriginFor<T>,
+	BoundedVec<<T as Config>::Remark, <T as Config>::MaxRemarksPerCall>,
+	Box<<T as Config>::RuntimeCall>,
+);
+
+/// The handler used to check remarks before and after call dispatch.
+pub trait RemarkDispatchHandler<T> {
+	fn pre_dispatch_check(t: T) -> DispatchResult;
+
+	fn post_dispatch_check(t: T) -> DispatchResult;
+}
+
+pub struct NoopRemarkDispatchHandler<T>(PhantomData<T>);
+
+impl<T> RemarkDispatchHandler<RemarkArgs<T>> for NoopRemarkDispatchHandler<T>
+where
+	T: Config,
+{
+	fn pre_dispatch_check(_t: RemarkArgs<T>) -> DispatchResult {
+		Ok(())
+	}
+
+	fn post_dispatch_check(_t: RemarkArgs<T>) -> DispatchResult {
+		Ok(())
+	}
+}

--- a/pallets/remarks/src/mock.rs
+++ b/pallets/remarks/src/mock.rs
@@ -1,0 +1,210 @@
+// Copyright 2023 Centrifuge Foundation (centrifuge.io).
+//
+// This file is part of the Centrifuge chain project.
+// Centrifuge is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version (see http://www.gnu.org/licenses).
+// Centrifuge is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+use frame_support::{
+	construct_runtime, pallet_prelude::ConstU32, parameter_types, traits::InstanceFilter,
+	BoundedVec,
+};
+use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
+use scale_info::TypeInfo;
+use sp_core::H256;
+use sp_runtime::traits::{BlakeTwo256, ConstU128, ConstU16, ConstU64, IdentityLookup};
+
+pub use crate as pallet_remarks;
+use crate::pallet::Config;
+
+construct_runtime!(
+	pub struct Runtime {
+		System: frame_system,
+		Balances: pallet_balances,
+		RemarkDispatchHandlerMock: pallet_mock_test,
+		Remarks: pallet_remarks,
+		Utility: pallet_utility,
+		Proxy: pallet_proxy,
+	}
+);
+
+impl frame_system::Config for Runtime {
+	type AccountData = pallet_balances::AccountData<Balance>;
+	type AccountId = u64;
+	type BaseCallFilter = frame_support::traits::Everything;
+	type Block = frame_system::mocking::MockBlock<Runtime>;
+	type BlockHashCount = ConstU64<250>;
+	type BlockLength = ();
+	type BlockWeights = ();
+	type DbWeight = ();
+	type Hash = H256;
+	type Hashing = BlakeTwo256;
+	type Lookup = IdentityLookup<Self::AccountId>;
+	type MaxConsumers = ConstU32<16>;
+	type Nonce = u64;
+	type OnKilledAccount = ();
+	type OnNewAccount = ();
+	type OnSetCode = ();
+	type PalletInfo = PalletInfo;
+	type RuntimeCall = RuntimeCall;
+	type RuntimeEvent = RuntimeEvent;
+	type RuntimeOrigin = RuntimeOrigin;
+	type SS58Prefix = ConstU16<42>;
+	type SystemWeightInfo = ();
+	type Version = ();
+}
+
+pub type Balance = u128;
+
+parameter_types! {
+	pub const MaxRemarksPerCall: u32 = 3;
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Encode, Decode, TypeInfo)]
+pub enum TestRemark {
+	SomeId(u32),
+	SomeBytes(BoundedVec<u8, ConstU32<16>>),
+}
+
+impl Default for TestRemark {
+	fn default() -> Self {
+		TestRemark::SomeBytes(
+			BoundedVec::try_from(vec![1, 2, 3]).expect("can build default test remark"),
+		)
+	}
+}
+
+#[allow(unused_imports)]
+#[frame_support::pallet]
+mod pallet_mock_test {
+	use frame_support::pallet_prelude::*;
+	use mock_builder::{execute_call, register_call};
+
+	use crate::{RemarkArgs, RemarkDispatchHandler};
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config + crate::Config {}
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	#[pallet::storage]
+	pub(super) type CallIds<T: Config> = StorageMap<
+		_,
+		Blake2_128Concat,
+		<Blake2_128 as frame_support::StorageHasher>::Output,
+		mock_builder::CallId,
+	>;
+
+	impl<T: Config> Pallet<T> {
+		pub fn mock_pre_dispatch_check(f: impl Fn(RemarkArgs<T>) -> DispatchResult + 'static) {
+			register_call!(move |t| f(t));
+		}
+
+		pub fn mock_post_dispatch_check(f: impl Fn(RemarkArgs<T>) -> DispatchResult + 'static) {
+			register_call!(move |t| f(t));
+		}
+	}
+
+	impl<T: Config> RemarkDispatchHandler<RemarkArgs<T>> for Pallet<T> {
+		fn pre_dispatch_check(t: RemarkArgs<T>) -> DispatchResult {
+			execute_call!(t)
+		}
+
+		fn post_dispatch_check(t: RemarkArgs<T>) -> DispatchResult {
+			execute_call!(t)
+		}
+	}
+}
+
+impl pallet_mock_test::Config for Runtime {}
+
+impl Config for Runtime {
+	type MaxRemarksPerCall = MaxRemarksPerCall;
+	type Remark = TestRemark;
+	type RemarkDispatchHandler = pallet_mock_test::Pallet<Runtime>;
+	type RuntimeCall = RuntimeCall;
+	type RuntimeEvent = RuntimeEvent;
+	type WeightInfo = ();
+}
+
+impl pallet_balances::Config for Runtime {
+	type AccountStore = System;
+	type Balance = Balance;
+	type DustRemoval = ();
+	type ExistentialDeposit = ConstU128<1>;
+	type FreezeIdentifier = ();
+	type MaxFreezes = ();
+	type MaxHolds = ConstU32<1>;
+	type MaxLocks = ConstU32<1>;
+	type MaxReserves = ();
+	type ReserveIdentifier = ();
+	type RuntimeEvent = RuntimeEvent;
+	type RuntimeHoldReason = ();
+	type WeightInfo = ();
+}
+
+impl pallet_utility::Config for Runtime {
+	type PalletsOrigin = OriginCaller;
+	type RuntimeCall = RuntimeCall;
+	type RuntimeEvent = RuntimeEvent;
+	type WeightInfo = ();
+}
+
+#[derive(
+	Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, MaxEncodedLen, TypeInfo,
+)]
+pub enum ProxyType {
+	Any,
+	None,
+}
+
+impl Default for ProxyType {
+	fn default() -> Self {
+		Self::Any
+	}
+}
+
+impl InstanceFilter<RuntimeCall> for ProxyType {
+	fn filter(&self, _c: &RuntimeCall) -> bool {
+		match self {
+			ProxyType::Any => true,
+			ProxyType::None => false,
+		}
+	}
+}
+
+impl pallet_proxy::Config for Runtime {
+	type AnnouncementDepositBase = ();
+	type AnnouncementDepositFactor = ();
+	type CallHasher = BlakeTwo256;
+	type Currency = ();
+	type MaxPending = ();
+	type MaxProxies = ();
+	type ProxyDepositBase = ();
+	type ProxyDepositFactor = ();
+	type ProxyType = ProxyType;
+	type RuntimeCall = RuntimeCall;
+	type RuntimeEvent = RuntimeEvent;
+	type WeightInfo = ();
+}
+
+// Build genesis storage according to the mock runtime.
+pub fn new_test_ext() -> sp_io::TestExternalities {
+	let mut ext = sp_io::TestExternalities::new(Default::default());
+
+	// Ensure that we set a block number otherwise no events would be deposited.
+	ext.execute_with(|| frame_system::Pallet::<Runtime>::set_block_number(1));
+
+	ext
+}
+
+#[allow(unused)]
+pub fn configure_mocks() {
+	RemarkDispatchHandlerMock::mock_pre_dispatch_check(move |_t| Ok(()));
+	RemarkDispatchHandlerMock::mock_post_dispatch_check(move |_t| Ok(()));
+}

--- a/pallets/remarks/src/tests.rs
+++ b/pallets/remarks/src/tests.rs
@@ -1,0 +1,257 @@
+// Copyright 2023 Centrifuge Foundation (centrifuge.io).
+//
+// This file is part of the Centrifuge chain project.
+// Centrifuge is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version (see http://www.gnu.org/licenses).
+// Centrifuge is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+use frame_support::{assert_noop, assert_ok, pallet_prelude::ConstU32, BoundedVec};
+use frame_system::Call as SystemCall;
+use pallet_balances::Call as BalancesCall;
+use pallet_proxy::Call as ProxyCall;
+use pallet_utility::Call as UtilityCall;
+use sp_runtime::DispatchError::BadOrigin;
+
+use crate::{mock::*, *};
+
+mod remark {
+	use super::*;
+
+	fn get_test_remarks() -> BoundedVec<TestRemark, MaxRemarksPerCall> {
+		BoundedVec::<TestRemark, MaxRemarksPerCall>::try_from(vec![
+			TestRemark::SomeId(1),
+			TestRemark::SomeId(2),
+			TestRemark::SomeBytes(
+				BoundedVec::<u8, ConstU32<16>>::try_from(vec![0, 1, 2])
+					.expect("can build remark bytes"),
+			),
+		])
+		.expect("can build remarks")
+	}
+
+	#[test]
+	fn success() {
+		new_test_ext().execute_with(|| {
+			let origin = RuntimeOrigin::signed(1);
+			let remarks = get_test_remarks();
+
+			let call = RuntimeCall::System(SystemCall::remark {
+				remark: vec![3, 4, 5],
+			});
+
+			let expected_pre_origin = origin.clone();
+			let expected_pre_remarks = remarks.clone();
+			let expected_pre_call = call.clone();
+
+			RemarkDispatchHandlerMock::mock_pre_dispatch_check(move |t| {
+				assert_eq!(t.0.as_signed(), expected_pre_origin.clone().as_signed());
+				assert_eq!(t.1, expected_pre_remarks);
+				assert_eq!(t.2, Box::new(expected_pre_call.clone()));
+
+				Ok(())
+			});
+
+			let expected_post_origin = origin.clone();
+			let expected_post_remarks = remarks.clone();
+			let expected_post_call = call.clone();
+
+			RemarkDispatchHandlerMock::mock_post_dispatch_check(move |t| {
+				assert_eq!(t.0.as_signed(), expected_post_origin.clone().as_signed());
+				assert_eq!(t.1, expected_post_remarks);
+				assert_eq!(t.2, Box::new(expected_post_call.clone()));
+
+				Ok(())
+			});
+
+			assert_ok!(Remarks::remark(
+				origin.clone(),
+				remarks.clone(),
+				call.clone().into()
+			));
+
+			let expected_event: RuntimeEvent = Event::<Runtime>::Remark { remarks, call }.into();
+
+			System::events()
+				.iter()
+				.find(|e| e.event == expected_event)
+				.expect("remark event is present");
+		});
+	}
+
+	#[test]
+	fn no_remarks() {
+		new_test_ext().execute_with(|| {
+			let call = RuntimeCall::System(SystemCall::remark {
+				remark: vec![3, 4, 5],
+			});
+
+			assert_noop!(
+				Remarks::remark(
+					RuntimeOrigin::signed(1),
+					Default::default(),
+					call.clone().into()
+				),
+				Error::<Runtime>::NoRemarks,
+			);
+		});
+	}
+
+	#[test]
+	fn pre_dispatch_failure() {
+		new_test_ext().execute_with(|| {
+			let remarks = get_test_remarks();
+
+			let call = RuntimeCall::System(SystemCall::remark {
+				remark: vec![3, 4, 5],
+			});
+
+			let expected_error = DispatchError::Other("pre-dispatch error");
+
+			RemarkDispatchHandlerMock::mock_pre_dispatch_check(move |_t| Err(expected_error));
+
+			assert_noop!(
+				Remarks::remark(
+					RuntimeOrigin::signed(1),
+					remarks.clone(),
+					call.clone().into()
+				),
+				expected_error
+			);
+		});
+	}
+
+	#[test]
+	fn post_dispatch_failure() {
+		new_test_ext().execute_with(|| {
+			let remarks = get_test_remarks();
+
+			let call = RuntimeCall::System(SystemCall::remark {
+				remark: vec![3, 4, 5],
+			});
+
+			RemarkDispatchHandlerMock::mock_pre_dispatch_check(move |_t| Ok(()));
+
+			let expected_error = DispatchError::Other("post-dispatch error");
+
+			RemarkDispatchHandlerMock::mock_post_dispatch_check(move |_t| Err(expected_error));
+
+			assert_noop!(
+				Remarks::remark(
+					RuntimeOrigin::signed(1),
+					remarks.clone(),
+					call.clone().into()
+				),
+				expected_error
+			);
+		});
+	}
+
+	#[test]
+	fn nested_remark_call_failure() {
+		new_test_ext().execute_with(|| {
+			let remarks = get_test_remarks();
+
+			let call = RuntimeCall::Remarks(Call::remark {
+				remarks: Default::default(),
+				call: Box::new(RuntimeCall::System(SystemCall::remark {
+					remark: vec![3, 4, 5],
+				})),
+			});
+
+			RemarkDispatchHandlerMock::mock_pre_dispatch_check(move |_t| Ok(()));
+
+			assert_noop!(
+				Remarks::remark(
+					RuntimeOrigin::signed(1),
+					remarks.clone(),
+					call.clone().into()
+				),
+				frame_system::Error::<Runtime>::CallFiltered
+			);
+		});
+	}
+
+	#[test]
+	fn remark_in_batch_call_success() {
+		new_test_ext().execute_with(|| {
+			let remarks = get_test_remarks();
+
+			let batch_call = RuntimeCall::Utility(UtilityCall::batch {
+				calls: vec![
+					RuntimeCall::Remarks(Call::remark {
+						remarks: Default::default(),
+						call: Box::new(RuntimeCall::System(SystemCall::remark {
+							remark: vec![1, 2, 3],
+						})),
+					}),
+					RuntimeCall::Remarks(Call::remark {
+						remarks: Default::default(),
+						call: Box::new(RuntimeCall::System(SystemCall::remark {
+							remark: vec![4, 5, 6],
+						})),
+					}),
+				],
+			});
+
+			RemarkDispatchHandlerMock::mock_pre_dispatch_check(move |_t| Ok(()));
+			RemarkDispatchHandlerMock::mock_post_dispatch_check(move |_t| Ok(()));
+
+			assert_ok!(Remarks::remark(
+				RuntimeOrigin::signed(1),
+				remarks.clone(),
+				batch_call.clone().into()
+			));
+		});
+	}
+
+	#[test]
+	fn inner_call_failure() {
+		new_test_ext().execute_with(|| {
+			let remarks = get_test_remarks();
+
+			let call = RuntimeCall::System(SystemCall::set_heap_pages { pages: 8 });
+
+			RemarkDispatchHandlerMock::mock_pre_dispatch_check(move |_t| Ok(()));
+
+			assert_noop!(
+				Remarks::remark(
+					RuntimeOrigin::signed(1),
+					remarks.clone(),
+					call.clone().into()
+				),
+				BadOrigin
+			);
+		});
+	}
+
+	#[test]
+	fn inner_proxy_call_failure() {
+		new_test_ext().execute_with(|| {
+			let remarks = get_test_remarks();
+
+			let proxy_origin = RuntimeOrigin::signed(1);
+			let real_origin = RuntimeOrigin::signed(2);
+			let transfer_dest = RuntimeOrigin::signed(3);
+
+			let call = RuntimeCall::Proxy(ProxyCall::proxy {
+				real: real_origin.as_signed().unwrap(),
+				force_proxy_type: None,
+				call: Box::new(RuntimeCall::Balances(BalancesCall::transfer {
+					dest: transfer_dest.as_signed().unwrap(),
+					value: 100,
+				})),
+			});
+
+			RemarkDispatchHandlerMock::mock_pre_dispatch_check(move |_t| Ok(()));
+
+			assert_noop!(
+				Remarks::remark(proxy_origin, remarks.clone(), call.clone().into()),
+				pallet_proxy::Error::<Runtime>::NotProxy,
+			);
+		});
+	}
+}

--- a/pallets/remarks/src/weights.rs
+++ b/pallets/remarks/src/weights.rs
@@ -1,0 +1,22 @@
+// Copyright 2023 Centrifuge Foundation (centrifuge.io).
+//
+// This file is part of the Centrifuge chain project.
+// Centrifuge is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version (see http://www.gnu.org/licenses).
+// Centrifuge is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+use frame_support::weights::Weight;
+
+pub trait WeightInfo {
+	fn remark(r: u32) -> Weight;
+}
+
+impl WeightInfo for () {
+	fn remark(_r: u32) -> Weight {
+		Weight::zero()
+	}
+}


### PR DESCRIPTION
# Descrition

- Add `pallet-remarks` into repo for this branch that was missing.
- Fix `pallet-remarks` benchmarking test that was failing. I'm not sure why CI does didn't check that 🤔 